### PR TITLE
the clientConfiguration could now be configured inside the .atoum.php file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ class Example extends atoum
     public function testExemple()
     {
         $this
-            ->blackfire($this->getBlackfireClient())
+            ->blackfire
                 ->assert('main.wall_time < 2s', "Temps d'execution")
                 ->profile(function() {
                     sleep(4); //just to make the test fail
@@ -72,7 +72,7 @@ $extension
 
 ```php
 $this
-    ->blackfire($this->getBlackfireClient())
+    ->blackfire
         ->defineMetric(new \Blackfire\Profile\Metric("example_method_calls", "=Example::method"))
         ->assert("metrics.example_method_calls.count < 10")
         ->profile(function() {
@@ -86,7 +86,7 @@ $this
 
 You can learn more about this on the [custom metric](https://blackfire.io/docs/reference-guide/metrics#custom-metrics)'s section of Blackfire documentation.
 
-### Pass your own configuration
+### Pass your own profile configuration
 
 ```php
 $this
@@ -95,7 +95,7 @@ $this
         $profileConfiguration->setTitle('Profile configuration title'),
         $testedClass = new TestedClass()
     )
-    ->blackfire($this->getBlackfireClient())
+    ->blackfire
         ->setConfiguration($profileConfiguration)
         ->assert("main.peak_memory < 10mb")
         ->profile(function() use ($testedClass) {
@@ -105,6 +105,24 @@ $this
 ```
 
 You can learn more about this on the [profile basic configurable](https://blackfire.io/docs/reference-guide/php-sdk#profile-basic-configuration)'s section of Blackfire documentation.
+
+### Pass a custom client
+
+You can either pass the blackfire client in the `.atoum.php` config file (when loading the extension). In that case the client will be used in all the blackfire assertions. You also can load/overload it in the `blackfire` assert. For example:
+
+```php
+$this
+    ->given(
+      $config = new \Blackfire\ClientConfiguration($_ENV['BLACKFIRE_CLIENT_ID'], $_ENV['BLACKFIRE_CLIENT_TOKEN']);
+      $client = new \Blackfire\Client($config);
+    )
+    ->blackfire(client)
+        ->assert('main.wall_time < 2s')
+        ->profile(function() {
+            //code to profile
+        })
+;
+```
 
 
 ## Test filtering

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Enable and configure the extension using atoum configuration file:
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
+$extension = new mageekguy\atoum\blackfire\extension();
 $extension
     ->setClientConfiguration(new \Blackfire\ClientConfiguration($_ENV['BLACKFIRE_CLIENT_ID'], $_ENV['BLACKFIRE_CLIENT_TOKEN']))
     ->addToRunner($runner)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ use atoum;
 
 class Example extends atoum
 {
-    private $blackfireClient;
-
     public function testExemple()
     {
         $this
@@ -36,16 +34,6 @@ class Example extends atoum
                 })
         ;
     }
-
-    private function getBlackfireClient()
-    {
-        if (null === $this->blackfireClient) {
-            $config = new \Blackfire\ClientConfiguration($_ENV['BLACKFIRE_CLIENT_ID'], $_ENV['BLACKFIRE_CLIENT_TOKEN']);
-            $this->blackfireClient = new \Blackfire\Client($config);
-        }
-
-        return $this->blackfireClient;
-    }
 }
 
 ```
@@ -62,7 +50,7 @@ Install extension using [composer](https://getcomposer.org):
 composer require --dev atoum/blackfire-extension
 ```
 
-Enable the extension using atoum configuration file:
+Enable and configure the extension using atoum configuration file:
 
 ```php
 <?php
@@ -71,7 +59,10 @@ Enable the extension using atoum configuration file:
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
-$runner->addExtension(new \mageekguy\atoum\blackfire\extension());
+$extension
+    ->setClientConfiguration(new \Blackfire\ClientConfiguration($_ENV['BLACKFIRE_CLIENT_ID'], $_ENV['BLACKFIRE_CLIENT_TOKEN']))
+    ->addToRunner($runner)
+;
 ```
 
 ## Test filtering

--- a/classes/configuration.php
+++ b/classes/configuration.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace mageekguy\atoum\blackfire;
+
+use Blackfire\ClientConfiguration;
+use mageekguy\atoum\observable;
+use mageekguy\atoum\runner;
+use mageekguy\atoum\test;
+
+class configuration implements \mageekguy\atoum\extension\configuration
+{
+    /**
+     * @var
+     */
+    private $clientConfiguration;
+
+    /**
+     * @return array
+     */
+    public function serialize()
+    {
+        return array(
+            'client_configuration' => serialize($this->clientConfiguration),
+        );
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return configuration
+     */
+    public static function unserialize(array $config)
+    {
+        $configuration = new static;
+
+        if (false !== ($clientConfiguration = unserialize($config['client_configuration']))) {
+            $configuration->setClientConfiguration($clientConfiguration);
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * @param ClientConfiguration $v
+     *
+     * @return $this
+     */
+    public function setClientConfiguration(ClientConfiguration $v = null)
+    {
+        $this->clientConfiguration = $v;
+
+        return $this;
+    }
+
+    /**
+     * @return ClientConfiguration
+     */
+    public function getClientConfiguration()
+    {
+        return $this->clientConfiguration;
+    }
+}


### PR DESCRIPTION
This PR on atoum will enable extensions to be configured in
the .atoum.php : atoum/atoum#529

We now can pass the ClientConfiguration to the extension.

This will remove the boilerplate inside the test file, it will
no longer be required to pass the Client to the asserter.
