### PR TITLE
execute the extension tests during the --test-it and --test-ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Enable the extension using atoum configuration file:
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
-$runner->addExtension(new \mageekguy\atoum\blackfire\extension());
+$runner->addExtension(new \mageekguy\atoum\blackfire\extension($script));
 ```
 
 ## Other examples

--- a/classes/extension.php
+++ b/classes/extension.php
@@ -3,6 +3,7 @@
 namespace mageekguy\atoum\blackfire;
 
 use Blackfire\Client;
+use Blackfire\ClientConfiguration;
 use mageekguy\atoum;
 use mageekguy\atoum\observable;
 use mageekguy\atoum\runner;
@@ -10,6 +11,24 @@ use mageekguy\atoum\test;
 
 class extension implements atoum\extension
 {
+    /**
+     * @param atoum\configurator $configurator
+     */
+    public function __construct(atoum\configurator $configurator = null)
+    {
+        if ($configurator)
+        {
+            $script = $configurator->getScript();
+            $testHandler = function($script, $argument, $values) {
+                $script->getRunner()->addTestsFromDirectory(dirname(__DIR__) . '/tests/units/classes');
+            };
+
+            $script
+                ->addArgumentHandler($testHandler, array('--test-ext'))
+                ->addArgumentHandler($testHandler, array('--test-it'))
+            ;
+        }
+    }
 
     public function setRunner(runner $runner)
     {


### PR DESCRIPTION
The blackfire extension tests are now executed during atoum's
--test-it and --test-ext options.

This will require to pass the $script to the extension construct
in the .atoum.php file.
