### PR TITLE
fix composer dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         }
     },
     "require": {
-        "atoum/atoum": "<3.0",
-        "blackfire/php-sdk": "^1.4"
+        "atoum/atoum": ">=1.0,<3.0",
+        "blackfire/php-sdk": ">=1.4.5,<2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"


### PR DESCRIPTION
Tests are now passing, even when getting the dependancies
with the --prefer-lowest option during a composer update.
